### PR TITLE
[fix] 이름 설정 예외 처리

### DIFF
--- a/app/src/main/java/com/jangjh123/shallwegoforawalk/ui/activity/register/RegisterActivity.kt
+++ b/app/src/main/java/com/jangjh123/shallwegoforawalk/ui/activity/register/RegisterActivity.kt
@@ -99,17 +99,20 @@ class RegisterActivity : BaseActivity<ActivityRegisterBinding>(R.layout.activity
 
                 setOnKeyListener { _, p1, _ ->
                     if (p1 == KeyEvent.KEYCODE_ENTER) {
-                        if (etName.text.isNotEmpty()) {
-                            viewModel!!.setName(etName.text.toString())
-                        } else {
-                            if (viewModel!!.dogName.value != null) {
-                                etName.setText(viewModel!!.dogName.value)
-                            }
-                        }
                         hideKeyboard(etName)
                         etName.clearFocus()
                     }
                     return@setOnKeyListener false
+                }
+
+                setOnFocusChangeListener { _, _ ->
+                    if (etName.text.isNotEmpty()) {
+                        viewModel!!.setName(etName.text.toString())
+                    } else {
+                        if (viewModel!!.dogName.value != null) {
+                            etName.setText(viewModel!!.dogName.value)
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
강아지 이름 설정시, 이름을 모두 작성하고 완료 버튼이 아닌 뒤로가기 등의 인터랙션을 통해 etName 이 포커스를 잃으면 카운트가 증가하지 않는 이슈 대응함.